### PR TITLE
fix .po parsing issue for multiline msgid

### DIFF
--- a/lib/Locale/Maketext/Lexicon/Getcontext.pm
+++ b/lib/Locale/Maketext/Lexicon/Getcontext.pm
@@ -69,7 +69,7 @@ sub parse {
     foreach (@_) {
         s/[\015\012]*\z//;    # fix CRLF issues
 
-        /^(msgctxt|msgstr) +"(.*)" *$/
+        /^(msgctxt|msgid|msgstr) +"(.*)" *$/
             ? do {            # leading strings
             $var{$1} = $2;
             $key = $1;
@@ -99,6 +99,8 @@ sub parse {
             $process->($_);
             }
             : ();
+
+	
 
     }
 

--- a/t/10-parse.t
+++ b/t/10-parse.t
@@ -31,6 +31,9 @@ my %field = (
         he  => "רכיבים",
         ja  => "材料",
     },
+    multiline_msgid => {
+	en => "Pouet pouetPouet",
+    },
 );
 
 plan tests => 1 + @files * (2 + keys %field);

--- a/t/po/off-common/en.po
+++ b/t/po/off-common/en.po
@@ -49,6 +49,12 @@ msgctxt "add_user_confirm"
 msgid "<p>Thanks for joining. You can now sign-in on the site to add and edit products.</p>"
 msgstr "<p>Thanks for joining. You can now sign-in on the site to add and edit products.</p>"
 
+msgctxt "multiline_msgid"
+msgid "Blabla\n"
+"Blablabla"
+msgstr "Pouet pouet"
+"Pouet"
+
 msgctxt "add_user_email_body"
 msgid "Hello <NAME>,\n"
 "\n"


### PR DESCRIPTION
Needed for the big msgid we have for email bodies.