### PR TITLE
Logical defined-OR operator was introduced in Perl v5.10

### DIFF
--- a/t/10-parse.t
+++ b/t/10-parse.t
@@ -56,8 +56,9 @@ for my $file (@files) {
     is $lexicon->{":langtag"}, $lc, ":langtag = $lc";
 
     for my $field (sort keys %field) {
-        is $lexicon->{$field}, $field{$field}{$lc},
-            "$field = " . ($field{$field}{$lc} // "<undef>");
+        my $value = $field{$field}{$lc};
+        is $lexicon->{$field}, $value,
+            "$field = " . (defined $value)?($value):("<undef>");
     }
 }
 


### PR DESCRIPTION
Hi @maddingue 

Please review the PR.

There are currently 22 FAIL reports because of the use of Logical defined-OR
operator and test environment being v5.8.*. I proposed to replace the logical
defined-OR operator with regular operator to support v5.8 as well.

https://www.cpantesters.org/distro/L/Locale-Maketext-Lexicon-Getcontext.html?oncpan=1&distmat=1&version=0.05&grade=3

Many Thanks.
Best Regards,
Mohammad S Anwar